### PR TITLE
Specify Qt version (>= 5.6.0) for cmake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ set(KF5_MIN_VERSION "5.15.0")
 find_package(ECM 5.15.0 REQUIRED CONFIG)
 set(CMAKE_MODULE_PATH ${cantor_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH} ${ECM_MODULE_PATH} ${ECM_KDE_MODULE_DIR})
 
-find_package(Qt5 CONFIG REQUIRED
+find_package(Qt5 5.6.0 CONFIG REQUIRED
     Core
     Widgets
     PrintSupport


### PR DESCRIPTION
In `CMakeLists.txt` Qt version don't set, so then I have tried to build `cantor` with my `Qt 5.5`, I have had compilation errors.
So I suggest to set minimal Qt version.