### PR TITLE
Suppress warnings

### DIFF
--- a/src/backends/maxima/maximacompletionobject.cpp
+++ b/src/backends/maxima/maximacompletionobject.cpp
@@ -61,7 +61,7 @@ void MaximaCompletionObject::fetchCompletions()
 
     const QString prefix = command();
     QStringList prefixCompletion;
-    for (const QString str : allCompletions)
+    for (const QString& str : allCompletions)
         if (str.startsWith(prefix))
             prefixCompletion << str;
 

--- a/src/backends/python/pythonserver.cpp
+++ b/src/backends/python/pythonserver.cpp
@@ -175,7 +175,7 @@ string PythonServer::variables(bool parseValue) const
 #elif PY_MAJOR_VERSION == 2
         "except ImportError: \n"
 #endif
-        "   pass \n", NULL
+        "   pass \n", nullptr
     );
 
     PyRun_SimpleString("__tmp_globals__ = globals()");
@@ -220,7 +220,7 @@ string PythonServer::variables(bool parseValue) const
 #elif PY_MAJOR_VERSION == 2
         "except ImportError: \n"
 #endif
-        "   pass \n", NULL
+        "   pass \n", nullptr
     );
 
 

--- a/src/backends/scilab/scilabexpression.cpp
+++ b/src/backends/scilab/scilabexpression.cpp
@@ -86,7 +86,7 @@ void ScilabExpression::parseOutput(QString output)
     qDebug() << "output: " << output;
     const QStringList lines = output.split(QLatin1String("\n"));
     bool isPrefixLines = true;
-    for (const QString line : lines)
+    for (const QString& line : lines)
     {
         if (isPrefixLines && line.isEmpty())
             continue;

--- a/src/lib/defaultvariablemodel.cpp
+++ b/src/lib/defaultvariablemodel.cpp
@@ -201,7 +201,7 @@ void DefaultVariableModel::clearVariables()
     beginResetModel();
 
     QStringList names;
-    for (const Variable var: d->variables)
+    for (const Variable& var: d->variables)
         names.append(var.name);
 
     d->variables.clear();
@@ -251,7 +251,7 @@ void DefaultVariableModel::setVariables(const QList<DefaultVariableModel::Variab
 
     // Handle added vars
     const int size = d->variables.size();
-    for (const Variable newvar : newVars)
+    for (const Variable& newvar : newVars)
     {
         bool found = false;
         for (int i = 0; i < size; i++)
@@ -337,7 +337,7 @@ QStringList DefaultVariableModel::variableNames() const
 {
     Q_D(const DefaultVariableModel);
     QStringList names;
-    for (const Variable var: d->variables)
+    for (const Variable& var: d->variables)
         names << var.name;
     return names;
 }


### PR DESCRIPTION
Suppress some warnings ([-Wzero-as-null-pointer-constant], [-Wrange-loop-construct]) that occurred when building with clang 11.